### PR TITLE
Add --delete to rsync command to clean up on remote.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ is the location of your production build.
 These files are suitable to be transferred directly to a production host. For example:
 
     sculpin generate --env=prod
-    rsync -avze 'ssh -p 999' output_prod/ user@yoursculpinsite.com:public_html
+    rsync -avze 'ssh -p 999' --delete output_prod/ user@yoursculpinsite.com:public_html
 
 In fact, `publish.sh` is provided to get you started. If you plan on deploying to an
 Amazon S3 bucket, you can use `s3-publish.sh` alongside the `s3cmd` utility (must be

--- a/publish.sh
+++ b/publish.sh
@@ -7,5 +7,5 @@
 sculpin generate --env=prod
 if [ $? -ne 0 ]; then echo "Could not generate the site"; exit 1; fi
 
-rsync -avze 'ssh -p 4668' output_prod/ username@yoursculpinsite:public_html
+rsync -avze 'ssh -p 4668' --delete output_prod/ username@yoursculpinsite:public_html
 if [ $? -ne 0 ]; then echo "Could not publish the site"; exit 1; fi


### PR DESCRIPTION
While this can be a bit dangerous, leaving it out can also be kinda sneaky if for instance wrote something that you later delete.
